### PR TITLE
Add conditional branching with boolean expression parsing

### DIFF
--- a/docs/Tagspeak_2.0.md
+++ b/docs/Tagspeak_2.0.md
@@ -50,3 +50,41 @@ This reads naturally and operates modularly:
 ---
 
 TagSpeak is intentionally **visually parseable** — for AIs, for humans, for scripts. Everything is a packet. Everything flows.
+
+## 🔀 Conditionals
+
+Use packets to express branching logic:
+
+```
+[if@(expr)]>[then]{ ... }>[or@(expr)]>[then]{ ... }>[else]{ ... }
+```
+
+* `[if@(expr)]` – evaluate the boolean expression.
+* `[or@(expr)]` – optional additional branches; each acts as an `else if`.
+* `[else]` – final fallback when no condition matched.
+
+Boolean expressions support both tag-style and symbolic operators:
+
+| Tag     | Symbol | Meaning |
+| ------- | ------ | ------- |
+| `[eq]`  | `==`   | equals  |
+| `[neq]` | `!=`   | not equals |
+| `[lt]`  | `<`    | less than |
+| `[gt]`  | `>`    | greater than |
+| `[and]` | `&&`   | logical and |
+| `[or]`  | `||`   | logical or |
+| `[not]` | `!`    | logical not |
+
+Example:
+
+```
+[math@1] > [store@x]
+
+[if@(x [eq] 2)]
+[then]{ [print@"eq branch"] }
+[or@(x == 1)]
+[then]{ [print@"double equals branch"] }
+[else]{ [print@"else branch"] }
+```
+
+The script above prints `double equals branch`.

--- a/examples/conditionals.tgsk
+++ b/examples/conditionals.tgsk
@@ -1,0 +1,14 @@
+[math@1] > [store@x]
+
+[if@(x [eq] 2)]
+[then]{
+    [print@"eq branch"]
+}
+[or@(x == 1)]
+[then]{
+    [print@"double equals branch"]
+}
+[else]{
+    [print@"else branch"]
+}
+

--- a/src/kernel/boolops.rs
+++ b/src/kernel/boolops.rs
@@ -1,5 +1,7 @@
 use crate::kernel::ast::{Comparator, CmpBase};
 use crate::kernel::values::Value;
+use crate::kernel::ast::{BExpr, Node, Arg, Packet};
+use anyhow::{Result, bail};
 
 pub fn reduce_op_chain_is_valid() -> bool { true } // placeholder if needed
 
@@ -39,3 +41,154 @@ fn to_num(v: &Value) -> anyhow::Result<f64> {
         _ => Err(anyhow::anyhow!("non-numeric value")),
     }
 }
+
+// === Boolean expression parsing ===
+
+#[derive(Debug, Clone)]
+enum Token {
+    Number(f64),
+    Ident(String),
+    Cmp(Comparator),
+    And,
+    Or,
+    Not,
+    LParen,
+    RParen,
+}
+
+struct Lexer<'a> {
+    src: &'a [u8],
+    i: usize,
+    len: usize,
+}
+
+impl<'a> Lexer<'a> {
+    fn new(s: &'a str) -> Self { Self { src: s.as_bytes(), i: 0, len: s.len() } }
+    fn peek(&self) -> Option<char> { (self.i < self.len).then(|| self.src[self.i] as char) }
+    fn next(&mut self) -> Option<char> { let c = self.peek()?; self.i += 1; Some(c) }
+    fn skip_ws(&mut self) { while let Some(c) = self.peek() { if c.is_whitespace() { self.i += 1; } else { break; } } }
+    fn starts_with(&self, s: &str) -> bool {
+        let n = s.len();
+        self.i + n <= self.len && &self.src[self.i..self.i+n] == s.as_bytes()
+    }
+    fn read_ident_or_number(&mut self) -> String {
+        let mut s = String::new();
+        while let Some(c) = self.peek() {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '.' { s.push(c); self.i += 1; }
+            else { break; }
+        }
+        s
+    }
+}
+
+fn lex(src: &str) -> Result<Vec<Token>> {
+    let mut lx = Lexer::new(src);
+    let mut out = Vec::new();
+    while lx.i < lx.len {
+        lx.skip_ws();
+        if lx.i >= lx.len { break; }
+        // punctuation and operators
+        if lx.starts_with("&&") { lx.i += 2; out.push(Token::And); continue; }
+        if lx.starts_with("||") { lx.i += 2; out.push(Token::Or); continue; }
+        if lx.starts_with("!") { lx.i += 1; out.push(Token::Not); continue; }
+        if lx.starts_with("==") { lx.i += 2; out.push(Token::Cmp(Comparator { base: CmpBase::Eq, include_eq: false, negate: false })); continue; }
+        if lx.starts_with("!=") { lx.i += 2; out.push(Token::Cmp(Comparator { base: CmpBase::Eq, include_eq: false, negate: true })); continue; }
+        if lx.starts_with("<=") { lx.i += 2; out.push(Token::Cmp(Comparator { base: CmpBase::Lt, include_eq: true, negate: false })); continue; }
+        if lx.starts_with(">=") { lx.i += 2; out.push(Token::Cmp(Comparator { base: CmpBase::Gt, include_eq: true, negate: false })); continue; }
+        if lx.starts_with("<") { lx.i += 1; out.push(Token::Cmp(Comparator { base: CmpBase::Lt, include_eq: false, negate: false })); continue; }
+        if lx.starts_with(">") { lx.i += 1; out.push(Token::Cmp(Comparator { base: CmpBase::Gt, include_eq: false, negate: false })); continue; }
+        if lx.starts_with("(") { lx.i += 1; out.push(Token::LParen); continue; }
+        if lx.starts_with(")") { lx.i += 1; out.push(Token::RParen); continue; }
+
+        // bracketed keywords
+        if lx.starts_with("[eq]") { lx.i += 4; out.push(Token::Cmp(Comparator { base: CmpBase::Eq, include_eq: false, negate: false })); continue; }
+        if lx.starts_with("[neq]") { lx.i += 5; out.push(Token::Cmp(Comparator { base: CmpBase::Eq, include_eq: false, negate: true })); continue; }
+        if lx.starts_with("[lt]") { lx.i += 4; out.push(Token::Cmp(Comparator { base: CmpBase::Lt, include_eq: false, negate: false })); continue; }
+        if lx.starts_with("[gt]") { lx.i += 4; out.push(Token::Cmp(Comparator { base: CmpBase::Gt, include_eq: false, negate: false })); continue; }
+        if lx.starts_with("[and]") { lx.i += 5; out.push(Token::And); continue; }
+        if lx.starts_with("[or]") { lx.i += 4; out.push(Token::Or); continue; }
+        if lx.starts_with("[not]") { lx.i += 5; out.push(Token::Not); continue; }
+
+        // identifiers or numbers
+        let word = lx.read_ident_or_number();
+        if word.is_empty() { bail!("unexpected token in expression"); }
+        if let Ok(n) = word.parse::<f64>() {
+            out.push(Token::Number(n));
+        } else {
+            out.push(Token::Ident(word));
+        }
+    }
+    Ok(out)
+}
+
+struct Parser { toks: Vec<Token>, i: usize }
+
+impl Parser {
+    fn new(t: Vec<Token>) -> Self { Self { toks: t, i: 0 } }
+    fn peek(&self) -> Option<&Token> { self.toks.get(self.i) }
+    fn next(&mut self) -> Option<Token> { if self.i < self.toks.len() { let t = self.toks[self.i].clone(); self.i += 1; Some(t) } else { None } }
+
+    fn parse_or(&mut self) -> Result<BExpr> {
+        let mut left = self.parse_and()?;
+        while matches!(self.peek(), Some(Token::Or)) {
+            self.next();
+            let right = self.parse_and()?;
+            left = BExpr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+    fn parse_and(&mut self) -> Result<BExpr> {
+        let mut left = self.parse_not()?;
+        while matches!(self.peek(), Some(Token::And)) {
+            self.next();
+            let right = self.parse_not()?;
+            left = BExpr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+    fn parse_not(&mut self) -> Result<BExpr> {
+        if matches!(self.peek(), Some(Token::Not)) {
+            self.next();
+            Ok(BExpr::Not(Box::new(self.parse_not()?)))
+        } else {
+            self.parse_cmp()
+        }
+    }
+    fn parse_cmp(&mut self) -> Result<BExpr> {
+        // handle parenthesized expression
+        if matches!(self.peek(), Some(Token::LParen)) {
+            self.next();
+            let expr = self.parse_or()?;
+            match self.next() {
+                Some(Token::RParen) => Ok(expr),
+                _ => bail!("expected )"),
+            }
+        } else {
+            let left = self.parse_operand()?;
+            if let Some(Token::Cmp(cmp)) = self.peek().cloned() {
+                self.next();
+                let right = self.parse_operand()?;
+                Ok(BExpr::Cmp { lhs: Box::new(left), cmp, rhs: Box::new(right) })
+            } else {
+                Ok(BExpr::Lit(Box::new(left)))
+            }
+        }
+    }
+    fn parse_operand(&mut self) -> Result<Node> {
+        match self.next() {
+            Some(Token::Number(n)) => Ok(Node::Packet(Packet { ns: None, op: "math".into(), arg: Some(Arg::Number(n)) })),
+            Some(Token::Ident(id)) => Ok(Node::Packet(Packet { ns: None, op: "math".into(), arg: Some(Arg::Ident(id)) })),
+            Some(Token::LParen) => bail!("unexpected '(' in operand"),
+            other => bail!("unexpected token {:?}", other),
+        }
+    }
+}
+
+pub fn parse_bexpr(src: &str) -> Result<BExpr> {
+    let toks = lex(src)?;
+    let mut p = Parser::new(toks);
+    let expr = p.parse_or()?;
+    if p.peek().is_some() { bail!("unexpected token at end"); }
+    Ok(expr)
+}
+

--- a/src/kernel/runtime.rs
+++ b/src/kernel/runtime.rs
@@ -1,7 +1,6 @@
 use std::collections::HashMap;
-use crate::kernel::ast::{Node, Packet, BExpr, /* Comparator if you already use it */};
+use crate::kernel::ast::{Node, Packet};
 use crate::kernel::values::Value;
-use crate::kernel::boolops::cmp_eval; // keep if you use conditionals later
 
 pub struct Runtime {
     pub vars: HashMap<String, Value>,
@@ -50,10 +49,8 @@ impl Runtime {
                 last
             }
             Node::Packet(p) => self.eval_packet(p)?,
-            // If you’ve implemented Node::If already, you can branch here:
-            Node::If { cond: _cond, then_b: _tb, else_b: _eb } => {
-                // Placeholder: wire later when your cond compiler is ready.
-                Value::Unit
+            Node::If { cond, then_b, else_b } => {
+                crate::packets::conditionals::exec(self, cond, then_b, else_b)?
             }
         };
         self.last = out.clone();

--- a/src/packets/conditionals.rs
+++ b/src/packets/conditionals.rs
@@ -1,6 +1,38 @@
 use anyhow::Result;
-use crate::kernel::{Runtime, Value, Packet};
+use crate::kernel::{Runtime, Value};
+use crate::kernel::ast::{BExpr, Node};
+use crate::kernel::boolops::cmp_eval;
 
-pub fn handle(_rt: &mut Runtime, _p: &Packet) -> Result<Value> {
-    anyhow::bail!("if/else not implemented yet")
+fn eval_bexpr(rt: &mut Runtime, expr: &BExpr) -> Result<bool> {
+    use BExpr::*;
+    Ok(match expr {
+        Cmp { lhs, cmp, rhs } => {
+            let a = rt.eval(lhs)?;
+            let b = rt.eval(rhs)?;
+            cmp_eval(cmp, &a, &b)?
+        }
+        And(a, b) => eval_bexpr(rt, a)? && eval_bexpr(rt, b)?,
+        Or(a, b) => eval_bexpr(rt, a)? || eval_bexpr(rt, b)?,
+        Not(x) => !eval_bexpr(rt, x)?,
+        Lit(n) => rt.eval(n)?.as_bool().unwrap_or(false),
+    })
 }
+
+fn run_block(rt: &mut Runtime, nodes: &[Node]) -> Result<Value> {
+    let mut last = Value::Unit;
+    for n in nodes {
+        last = rt.eval(n)?;
+    }
+    Ok(last)
+}
+
+pub fn exec(rt: &mut Runtime, cond: &BExpr, then_b: &[Node], else_b: &[Node]) -> Result<Value> {
+    if eval_bexpr(rt, cond)? {
+        run_block(rt, then_b)
+    } else if else_b.is_empty() {
+        Ok(Value::Unit)
+    } else {
+        run_block(rt, else_b)
+    }
+}
+


### PR DESCRIPTION
## Summary
- support `[if]`, `[or]`, and `[else]` packets with nested `Node::If` trees
- implement boolean expression parser with comparators and logical operators
- execute conditionals at runtime and document usage with examples

## Testing
- `cargo check`
- `cargo run -- examples/conditionals.tgsk`
