### PR TITLE
fix: refresh icons without restarting Explorer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -483,6 +483,7 @@ dependencies = [
  "native-windows-derive",
  "native-windows-gui",
  "which",
+ "windows-sys 0.52.0",
  "winreg",
  "winres",
 ]
@@ -655,6 +656,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
 dependencies = [
  "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = "1"
 winreg = "0.52"
 native-windows-gui = "1.0.13"
 native-windows-derive = "1.0"
+windows-sys = { version = "0.52", features = ["Win32_UI_Shell"] }
 
 
 [build-dependencies]

--- a/src/bin/tagspeak_setup.rs
+++ b/src/bin/tagspeak_setup.rs
@@ -185,7 +185,9 @@ impl App {
                 }
             }
             Ok(s) => {
-                self.set_busy(false, &format!("Build failed (exit code {s})"));
+                // [myth] goal: surface the numeric exit code
+                let code = s.code().map(|c| c.to_string()).unwrap_or_else(|| "unknown".into());
+                self.set_busy(false, &format!("Build failed (exit code {code})"));
             }
             Err(e) => {
                 self.set_busy(false, &format!("Couldn’t launch cargo: {e}"));
@@ -276,6 +278,14 @@ fn do_uninstall() -> Result<()> {
 fn refresh_icons() -> Result<()> {
     // [myth] goal: refresh icons without tanking Explorer
     // [myth] tradeoff: if the call fails, we don't get feedback
-    unsafe { SHChangeNotify(SHCNE_ASSOCCHANGED, SHCNF_IDLIST, 0, 0); }
+    // SAFETY: pointers are null and flags are documented constants
+    unsafe {
+        SHChangeNotify(
+            SHCNE_ASSOCCHANGED as i32,
+            SHCNF_IDLIST,
+            std::ptr::null(),
+            std::ptr::null(),
+        );
+    }
     Ok(())
 }

--- a/src/bin/tagspeak_setup.rs
+++ b/src/bin/tagspeak_setup.rs
@@ -283,8 +283,8 @@ fn refresh_icons() -> Result<()> {
         SHChangeNotify(
             SHCNE_ASSOCCHANGED as i32,
             SHCNF_IDLIST,
-            std::ptr::null(),
-            std::ptr::null(),
+            std::ptr::null::<std::ffi::c_void>(),
+            std::ptr::null::<std::ffi::c_void>(),
         );
     }
     Ok(())


### PR DESCRIPTION
## Summary
- use SHChangeNotify to refresh file icons without terminating Explorer
- add windows-sys dependency for shell notifications

## Testing
- `cargo test` *(fails: native-windows-gui build errors on non-Windows host)*

------
https://chatgpt.com/codex/tasks/task_e_68ad1a5e533c832eb07214e133f45bfc