### PR TITLE
Add infix comparison parsing to TagSpeak conditionals

### DIFF
--- a/examples/infix_if_else.tgsk
+++ b/examples/infix_if_else.tgsk
@@ -1,0 +1,13 @@
+[funct:test]>{
+    [note@"Notice how > is used."]
+    [if@(1>1)]>{[math@10]>[store@x]}>
+
+    [note@"[lt] is just as valid as < also."]
+    [or@(1[lt]1)]>{[math@20]>[store@x]}>
+
+    [note@"since both are false, the fuction defaults to else."]
+    [else]>{[math@30]>[store@x]}
+}>
+[loop1@test]>
+[print@x]
+[note@"Final result should be 30."]

--- a/src/packets/conditionals.rs
+++ b/src/packets/conditionals.rs
@@ -1,5 +1,6 @@
+use crate::kernel::ast::CmpBase;
+use crate::kernel::{Arg, BExpr, Comparator, Node, Packet, Runtime, Value};
 use anyhow::Result;
-use crate::kernel::{Runtime, Value, BExpr};
 
 // [myth] goal: branch like a choose-your-own-adventure (no paper cuts)
 pub fn handle(_rt: &mut Runtime, _p: &crate::kernel::Packet) -> Result<Value> {
@@ -7,6 +8,57 @@ pub fn handle(_rt: &mut Runtime, _p: &crate::kernel::Packet) -> Result<Value> {
 }
 
 pub fn parse_cond(src: &str) -> BExpr {
+    fn token_to_node(tok: &str) -> Node {
+        let tok = tok.trim();
+        let arg = if let Ok(n) = tok.parse::<f64>() {
+            Arg::Number(n)
+        } else if tok
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '.')
+        {
+            Arg::Ident(tok.to_string())
+        } else {
+            Arg::Str(tok.to_string())
+        };
+        Node::Packet(Packet {
+            ns: None,
+            op: "math".to_string(),
+            arg: Some(arg),
+            body: None,
+        })
+    }
+
+    let specs = [
+        ("[ge]", CmpBase::Gt, true, false),
+        ("[le]", CmpBase::Lt, true, false),
+        ("[ne]", CmpBase::Eq, false, true),
+        ("[eq]", CmpBase::Eq, false, false),
+        ("[gt]", CmpBase::Gt, false, false),
+        ("[lt]", CmpBase::Lt, false, false),
+        (">=", CmpBase::Gt, true, false),
+        ("<=", CmpBase::Lt, true, false),
+        ("!=", CmpBase::Eq, false, true),
+        ("==", CmpBase::Eq, false, false),
+        (">", CmpBase::Gt, false, false),
+        ("<", CmpBase::Lt, false, false),
+    ];
+
+    for (pat, base, include_eq, negate) in specs.iter() {
+        if let Some(idx) = src.find(pat) {
+            let lhs = token_to_node(&src[..idx]);
+            let rhs = token_to_node(&src[idx + pat.len()..]);
+            return BExpr::Cmp {
+                lhs: Box::new(lhs),
+                cmp: Comparator {
+                    base: base.clone(),
+                    include_eq: *include_eq,
+                    negate: *negate,
+                },
+                rhs: Box::new(rhs),
+            };
+        }
+    }
+
     BExpr::Lit(src.to_string())
 }
 
@@ -54,8 +106,7 @@ mod tests {
     #[test]
     fn packet_eq_in_if() -> Result<()> {
         // [myth] goal: compare vars via [eq]
-        let script = "[math@5]>[store@a]>[math@5]>[store@b]>"
-            .to_string()
+        let script = "[math@5]>[store@a]>[math@5]>[store@b]>".to_string()
             + "[if@([eq@a b])]>[then]{[math@1]>[store@res]}>"
             + "[else]>[then]{[math@0]>[store@res]}";
         let mut rt = Runtime::new();
@@ -68,8 +119,7 @@ mod tests {
     #[test]
     fn and_chain_with_stores() -> Result<()> {
         // [myth] goal: chain comparisons then and them
-        let script = "[math@7]>[store@x]>[math@8]>[store@y]>"
-            .to_string()
+        let script = "[math@7]>[store@x]>[math@8]>[store@y]>".to_string()
             + "[gt@x 5]>[store@c1]>[lt@y 10]>[store@c2]>"
             + "[if@([and@c1 c2])]>[then]{[math@1]>[store@res]}>"
             + "[else]>[then]{[math@0]>[store@res]}";
@@ -83,8 +133,7 @@ mod tests {
     #[test]
     fn stored_cmp_reuse() -> Result<()> {
         // [myth] goal: reuse stored boolean from comparator
-        let script = "[math@5]>[store@x]>[math@6]>[store@y]>"
-            .to_string()
+        let script = "[math@5]>[store@x]>[math@6]>[store@y]>".to_string()
             + "[eq@x y]>[store@cmp]>"
             + "[if@([eq@cmp false])]>[then]{[math@1]>[store@res]}>"
             + "[else]>[then]{[math@0]>[store@res]}";
@@ -92,6 +141,21 @@ mod tests {
         let node = router::parse(&script)?;
         rt.eval(&node)?;
         assert_eq!(rt.get_num("res"), Some(1.0));
+        Ok(())
+    }
+
+    #[test]
+    fn infix_cmp_falls_to_else() -> Result<()> {
+        // [myth] goal: support infix comparators like 1>1 and 1[lt]1
+        let script = r#"
+            [if@(1>1)]>[then]{[math@10]>[store@x]}>
+            [or@(1[lt]1)]>[then]{[math@20]>[store@x]}>
+            [else]>[then]{[math@30]>[store@x]}
+        "#;
+        let mut rt = Runtime::new();
+        let node = router::parse(script)?;
+        rt.eval(&node)?;
+        assert_eq!(rt.get_num("x"), Some(30.0));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- parse `if@(1>2)` and `if@(1[lt]2)` style infix comparisons
- add example script demonstrating infix comparisons
- test conditional fallback when all branches are false

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ad59824dd8832e90b3711d2bef507c