### PR TITLE
feat: add infix conditional parsing

### DIFF
--- a/examples/cond_infix.tgsk
+++ b/examples/cond_infix.tgsk
@@ -1,0 +1,5 @@
+// Demonstrates infix comparison operators in conditionals
+[if@(1>1)]>[then]{[math@10]>[store@x]}
+>[or@(1[lt]1)]>[then]{[math@20]>[store@x]}
+>[else]>[then]{[math@30]>[store@x]}
+[print@x]

--- a/src/packets/conditionals.rs
+++ b/src/packets/conditionals.rs
@@ -1,5 +1,6 @@
+use crate::kernel::ast::CmpBase;
+use crate::kernel::{Arg, BExpr, Comparator, Node, Packet, Runtime, Value};
 use anyhow::Result;
-use crate::kernel::{Runtime, Value, BExpr};
 
 // [myth] goal: branch like a choose-your-own-adventure (no paper cuts)
 pub fn handle(_rt: &mut Runtime, _p: &crate::kernel::Packet) -> Result<Value> {
@@ -7,7 +8,231 @@ pub fn handle(_rt: &mut Runtime, _p: &crate::kernel::Packet) -> Result<Value> {
 }
 
 pub fn parse_cond(src: &str) -> BExpr {
+    let s = src.trim();
+
+    // try logical OR first (lowest precedence)
+    for pat in ["||", "[or]"] {
+        if let Some(idx) = s.find(pat) {
+            let lhs = parse_cond(&s[..idx]);
+            let rhs = parse_cond(&s[idx + pat.len()..]);
+            return BExpr::Or(Box::new(lhs), Box::new(rhs));
+        }
+    }
+
+    // then logical AND
+    for pat in ["&&", "[and]"] {
+        if let Some(idx) = s.find(pat) {
+            let lhs = parse_cond(&s[..idx]);
+            let rhs = parse_cond(&s[idx + pat.len()..]);
+            return BExpr::And(Box::new(lhs), Box::new(rhs));
+        }
+    }
+
+    // unary NOT
+    for pat in ["!", "[not]"] {
+        if s.starts_with(pat) {
+            let inner = parse_cond(&s[pat.len()..]);
+            return BExpr::Not(Box::new(inner));
+        }
+    }
+
+    // comparison operators
+    let ops: [(&str, Comparator); 18] = [
+        (
+            "[!=]",
+            Comparator {
+                base: CmpBase::Eq,
+                include_eq: false,
+                negate: true,
+            },
+        ),
+        (
+            "[ne]",
+            Comparator {
+                base: CmpBase::Eq,
+                include_eq: false,
+                negate: true,
+            },
+        ),
+        (
+            "!=",
+            Comparator {
+                base: CmpBase::Eq,
+                include_eq: false,
+                negate: true,
+            },
+        ),
+        (
+            "[>=]",
+            Comparator {
+                base: CmpBase::Gt,
+                include_eq: true,
+                negate: false,
+            },
+        ),
+        (
+            "[ge]",
+            Comparator {
+                base: CmpBase::Gt,
+                include_eq: true,
+                negate: false,
+            },
+        ),
+        (
+            ">=",
+            Comparator {
+                base: CmpBase::Gt,
+                include_eq: true,
+                negate: false,
+            },
+        ),
+        (
+            "[<=]",
+            Comparator {
+                base: CmpBase::Lt,
+                include_eq: true,
+                negate: false,
+            },
+        ),
+        (
+            "[le]",
+            Comparator {
+                base: CmpBase::Lt,
+                include_eq: true,
+                negate: false,
+            },
+        ),
+        (
+            "<=",
+            Comparator {
+                base: CmpBase::Lt,
+                include_eq: true,
+                negate: false,
+            },
+        ),
+        (
+            "[>]",
+            Comparator {
+                base: CmpBase::Gt,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "[gt]",
+            Comparator {
+                base: CmpBase::Gt,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            ">",
+            Comparator {
+                base: CmpBase::Gt,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "[<]",
+            Comparator {
+                base: CmpBase::Lt,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "[lt]",
+            Comparator {
+                base: CmpBase::Lt,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "<",
+            Comparator {
+                base: CmpBase::Lt,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "[=]",
+            Comparator {
+                base: CmpBase::Eq,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "[eq]",
+            Comparator {
+                base: CmpBase::Eq,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+        (
+            "==",
+            Comparator {
+                base: CmpBase::Eq,
+                include_eq: false,
+                negate: false,
+            },
+        ),
+    ];
+
+    for (pat, cmp) in ops.iter() {
+        if let Some(idx) = s.find(pat) {
+            let lhs_src = s[..idx].trim();
+            let rhs_src = s[idx + pat.len()..].trim();
+            if let (Some(lhs), Some(rhs)) = (parse_atom(lhs_src), parse_atom(rhs_src)) {
+                return BExpr::Cmp {
+                    lhs: Box::new(lhs),
+                    cmp: cmp.clone(),
+                    rhs: Box::new(rhs),
+                };
+            } else {
+                return BExpr::Lit(src.to_string());
+            }
+        }
+    }
+
     BExpr::Lit(src.to_string())
+}
+
+fn parse_atom(tok: &str) -> Option<Node> {
+    let t = tok.trim();
+    if t.starts_with('[') {
+        crate::router::parse(t).ok()
+    } else if let Ok(n) = t.parse::<f64>() {
+        Some(Node::Packet(Packet {
+            ns: None,
+            op: "math".into(),
+            arg: Some(Arg::Number(n)),
+            body: None,
+        }))
+    } else if is_ident_like(t) {
+        Some(Node::Packet(Packet {
+            ns: None,
+            op: "math".into(),
+            arg: Some(Arg::Ident(t.to_string())),
+            body: None,
+        }))
+    } else {
+        None
+    }
+}
+
+fn is_ident_like(s: &str) -> bool {
+    let mut it = s.chars();
+    match it.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    it.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
 pub fn eval_cond(rt: &mut Runtime, cond: &BExpr) -> Result<bool> {
@@ -41,13 +266,25 @@ mod tests {
     #[test]
     fn or_else_chain() -> Result<()> {
         // [myth] goal: ensure or/else pick first truthy branch
-        let script = "[if@([math@0])]>[then]{[math@1]>[store@x]}>
-                      [or@([math@1])]>[then]{[math@2]>[store@x]}>
+        let script = "[if@([math@0])]>[then]{[math@1]>[store@x]}>\
+                      [or@([math@1])]>[then]{[math@2]>[store@x]}>\
                       [else]>[then]{[math@3]>[store@x]}";
         let mut rt = Runtime::new();
         let node = router::parse(script)?;
         rt.eval(&node)?;
         assert_eq!(rt.get_num("x"), Some(2.0));
+        Ok(())
+    }
+
+    #[test]
+    fn infix_comparators() -> Result<()> {
+        let script = "[if@(1>1)]>[then]{[math@10]>[store@x]}>\
+                      [or@(1[lt]1)]>[then]{[math@20]>[store@x]}>\
+                      [else]>[then]{[math@30]>[store@x]}";
+        let mut rt = Runtime::new();
+        let node = router::parse(script)?;
+        rt.eval(&node)?;
+        assert_eq!(rt.get_num("x"), Some(30.0));
         Ok(())
     }
 }


### PR DESCRIPTION
## Summary
- allow `[if@(1>1)]` style infix comparison operators alongside packet aliases
- parse logical `&&`, `||`, and `!` within condition expressions
- add example showcasing infix conditional syntax

## Testing
- `cargo test` *(fails: winreg crate not supported for non-Windows targets)*

------
https://chatgpt.com/codex/tasks/task_e_68ad62e2e2b0832e98f3185ad36ed9d7