### PR TITLE
Add YAML parsing to load packet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -474,6 +474,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -957,6 +963,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -993,6 +1005,31 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1095,6 +1132,9 @@ dependencies = [
  "meval",
  "native-windows-derive",
  "native-windows-gui",
+ "serde",
+ "serde_json",
+ "serde_yaml",
  "which",
  "windows-sys 0.52.0",
  "winit",
@@ -1190,6 +1230,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,9 @@ native-windows-gui = { version = "1.0.13", optional = true }
 native-windows-derive = { version = "1.0", optional = true }
 windows-sys = { version = "0.52", features = ["Win32_UI_Shell"], optional = true }
 winit = { version = "0.28", optional = true }
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+serde_yaml = "0.9"
 
 [build-dependencies]
 winres = { version = "0.1", optional = true }

--- a/examples/load_yaml/main.tgsk
+++ b/examples/load_yaml/main.tgsk
@@ -1,0 +1,1 @@
+[load@/config.yaml]>[store@cfg]>[print@cfg]

--- a/src/packets/load.rs
+++ b/src/packets/load.rs
@@ -2,6 +2,8 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
+use serde_yaml::Value as YamlValue;
+
 use crate::kernel::ast::Arg;
 use crate::kernel::fs_guard::resolve;
 use crate::kernel::{Packet, Runtime, Value};
@@ -29,7 +31,15 @@ pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
     };
 
     let path = resolve(root, &candidate)?;
-    let content = fs::read_to_string(path)?;
+    let content = fs::read_to_string(&path)?;
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+    let content = match ext {
+        "yaml" | "yml" => {
+            let val: YamlValue = serde_yaml::from_str(&content)?;
+            serde_json::to_string(&val)?
+        }
+        _ => content,
+    };
     Ok(Value::Str(content))
 }
 
@@ -48,6 +58,28 @@ mod tests {
         fs::write(base.join("something/config.json"), "{\"hi\":1}").unwrap();
         let script = base.join("sub").join("main.tgsk");
         fs::write(&script, "[load@/something/config.json]>[store@cfg]").unwrap();
+
+        let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
+        let mut rt = Runtime::from_entry(&script).unwrap();
+        let _ = rt.eval(&ast).unwrap();
+        match rt.get_var("cfg") {
+            Some(Value::Str(s)) => assert_eq!(s, "{\"hi\":1}"),
+            other => panic!("unexpected value: {:?}", other),
+        }
+
+        fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn loads_yaml_file_within_red_root() {
+        let base = std::env::temp_dir().join(format!("tgsk_load_yaml_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(base.join("sub")).unwrap();
+        fs::create_dir_all(base.join("something")).unwrap();
+        fs::write(base.join("red.tgsk"), "").unwrap();
+        fs::write(base.join("something/config.yaml"), "hi: 1\n").unwrap();
+        let script = base.join("sub").join("main.tgsk");
+        fs::write(&script, "[load@/something/config.yaml]>[store@cfg]").unwrap();
 
         let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
         let mut rt = Runtime::from_entry(&script).unwrap();


### PR DESCRIPTION
## Summary
- support reading `.yaml` and `.yml` files in the `load` packet by converting them to JSON strings
- add serde_yaml/serde_json dependencies
- provide YAML load example

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ad8f0e0538832e92a4a145fd023891