### PR TITLE
Add save and edit packets with JSON document support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -362,6 +362,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fdeflate"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -549,6 +555,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -952,8 +964,21 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1144,12 +1169,26 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "toml 0.8.23",
  "which",
  "windows-sys 0.52.0",
  "winit",
  "winreg",
  "winres",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1464,7 +1503,7 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "rustix",
+ "rustix 0.38.44",
  "winsafe",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 toml = "0.8"
+tempfile = "3"
 
 [build-dependencies]
 winres = { version = "0.1", optional = true }

--- a/examples/load_demos/modify_demo/hello.json
+++ b/examples/load_demos/modify_demo/hello.json
@@ -1,0 +1,3 @@
+{
+  "greeting": "Hello, World!"
+}

--- a/examples/load_demos/trailing-comma-case-study.tgsk
+++ b/examples/load_demos/trailing-comma-case-study.tgsk
@@ -1,0 +1,17 @@
+[loop3]{
+    # Step 1: Start fresh from disk
+    [load@modify_demo/hello.json] > [save@hello]
+
+    # Step 2: Insert a new key "test"
+    [mod@hello]{ 
+        [ins(test)@42] 
+    } > [save@hello]
+
+    # Step 3: Reload from disk (forces "test" to be last in file)
+    [load@modify_demo/hello.json] > [save@hello]
+
+    # Step 4: Delete "test" key
+    [mod@hello]{ 
+        [del(test)] 
+    } > [save@hello] > [print@hello]
+} > [save@final_json] > [print@final_json]

--- a/src/kernel/runtime.rs
+++ b/src/kernel/runtime.rs
@@ -106,6 +106,8 @@ impl Runtime {
             (None, "store") => crate::packets::store::handle(self, p),
             (None, "print") => crate::packets::print::handle(self, p),
             (None, "load") => crate::packets::load::handle(self, p),
+            (None, "save") => crate::packets::save::handle(self, p),
+            (None, "mod") => crate::packets::modify::handle(self, p),
 
             // loop forms: [loop3@tag] or [loop@N]{...}
             (None, op) if op.starts_with("loop") => crate::packets::r#loop::handle(self, p),

--- a/src/kernel/values.rs
+++ b/src/kernel/values.rs
@@ -1,17 +1,56 @@
 // values.rs
+use std::path::PathBuf;
+use std::time::SystemTime;
+
+use serde_json::Value as JsonValue;
+
 #[derive(Clone, Debug)]
-pub enum Value { Unit, Bool(bool), Num(f64), Str(String) }
+pub enum Value {
+    Unit,
+    Bool(bool),
+    Num(f64),
+    Str(String),
+    Doc(Document),
+}
+
+#[derive(Clone, Debug)]
+pub struct Document {
+    pub json: JsonValue,
+    pub path: PathBuf,
+    pub ext: String,
+    pub mtime: SystemTime,
+    pub root: PathBuf,
+    pub last_json: JsonValue,
+}
 
 impl Value {
     pub fn as_bool(&self) -> Option<bool> {
         match self {
             Value::Bool(b) => Some(*b),
-            Value::Num(n)  => Some(*n != 0.0 && !n.is_nan()),
-            Value::Str(s)  => Some(!s.is_empty()),
-            Value::Unit    => Some(false),
+            Value::Num(n) => Some(*n != 0.0 && !n.is_nan()),
+            Value::Str(s) => Some(!s.is_empty()),
+            Value::Unit => Some(false),
+            Value::Doc(_) => Some(true),
         }
     }
     pub fn try_num(&self) -> Option<f64> {
-        match self { Value::Num(n) => Some(*n), Value::Str(s) => s.parse().ok(), _ => None }
+        match self {
+            Value::Num(n) => Some(*n),
+            Value::Str(s) => s.parse().ok(),
+            _ => None,
+        }
+    }
+}
+
+impl Document {
+    pub fn new(json: JsonValue, path: PathBuf, ext: String, mtime: SystemTime, root: PathBuf) -> Self {
+        Self {
+            last_json: json.clone(),
+            json,
+            path,
+            ext,
+            mtime,
+            root,
+        }
     }
 }

--- a/src/packets/load.rs
+++ b/src/packets/load.rs
@@ -2,11 +2,13 @@ use anyhow::Result;
 use std::fs;
 use std::path::Path;
 
+use serde_json::Value as JsonValue;
 use serde_yaml::Value as YamlValue;
 use toml::Value as TomlValue;
 
 use crate::kernel::ast::Arg;
 use crate::kernel::fs_guard::resolve;
+use crate::kernel::values::Document;
 use crate::kernel::{Packet, Runtime, Value};
 
 pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
@@ -33,25 +35,32 @@ pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
 
     let path = resolve(root, &candidate)?;
     let content = fs::read_to_string(&path)?;
-    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
-    let content = match ext {
+    let meta = fs::metadata(&path)?;
+    let mtime = meta.modified()?;
+    let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_string();
+
+    let json: JsonValue = match ext.as_str() {
         "yaml" | "yml" => {
             let val: YamlValue = serde_yaml::from_str(&content)?;
-            serde_json::to_string(&val)?
+            serde_json::to_value(val)?
         }
         "toml" => {
             let val: TomlValue = toml::from_str(&content)?;
-            serde_json::to_string(&val)?
+            serde_json::to_value(val)?
         }
-        _ => content,
+        "json" | "" => serde_json::from_str(&content)?,
+        _ => anyhow::bail!("format_unsupported"),
     };
-    Ok(Value::Str(content))
+
+    let doc = Document::new(json, path, ext, mtime, root.clone());
+    Ok(Value::Doc(doc))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::fs;
+    use serde_json::json;
 
     #[test]
     fn loads_file_within_red_root() {
@@ -62,13 +71,13 @@ mod tests {
         fs::write(base.join("red.tgsk"), "").unwrap();
         fs::write(base.join("something/config.json"), "{\"hi\":1}").unwrap();
         let script = base.join("sub").join("main.tgsk");
-        fs::write(&script, "[load@/something/config.json]>[store@cfg]").unwrap();
+        fs::write(&script, "[load@/something/config.json]>[save@cfg]").unwrap();
 
         let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
         let mut rt = Runtime::from_entry(&script).unwrap();
         let _ = rt.eval(&ast).unwrap();
         match rt.get_var("cfg") {
-            Some(Value::Str(s)) => assert_eq!(s, "{\"hi\":1}"),
+            Some(Value::Doc(doc)) => assert_eq!(doc.json, json!({"hi":1})),
             other => panic!("unexpected value: {:?}", other),
         }
 
@@ -84,13 +93,13 @@ mod tests {
         fs::write(base.join("red.tgsk"), "").unwrap();
         fs::write(base.join("something/config.yaml"), "hi: 1\n").unwrap();
         let script = base.join("sub").join("main.tgsk");
-        fs::write(&script, "[load@/something/config.yaml]>[store@cfg]").unwrap();
+        fs::write(&script, "[load@/something/config.yaml]>[save@cfg]").unwrap();
 
         let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
         let mut rt = Runtime::from_entry(&script).unwrap();
         let _ = rt.eval(&ast).unwrap();
         match rt.get_var("cfg") {
-            Some(Value::Str(s)) => assert_eq!(s, "{\"hi\":1}"),
+            Some(Value::Doc(doc)) => assert_eq!(doc.json, json!({"hi":1})),
             other => panic!("unexpected value: {:?}", other),
         }
 
@@ -106,13 +115,13 @@ mod tests {
         fs::write(base.join("red.tgsk"), "").unwrap();
         fs::write(base.join("something/config.toml"), "hi = 1\n").unwrap();
         let script = base.join("sub").join("main.tgsk");
-        fs::write(&script, "[load@/something/config.toml]>[store@cfg]").unwrap();
+        fs::write(&script, "[load@/something/config.toml]>[save@cfg]").unwrap();
 
         let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
         let mut rt = Runtime::from_entry(&script).unwrap();
         let _ = rt.eval(&ast).unwrap();
         match rt.get_var("cfg") {
-            Some(Value::Str(s)) => assert_eq!(s, "{\"hi\":1}"),
+            Some(Value::Doc(doc)) => assert_eq!(doc.json, json!({"hi":1})),
             other => panic!("unexpected value: {:?}", other),
         }
 

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -6,3 +6,5 @@ pub mod math;
 pub mod note;
 pub mod print;
 pub mod store;
+pub mod save;
+pub mod modify;

--- a/src/packets/modify.rs
+++ b/src/packets/modify.rs
@@ -1,0 +1,243 @@
+use anyhow::{bail, Result};
+use crate::kernel::ast::{Arg, Node, Packet};
+use crate::kernel::values::{Document, Value};
+use crate::kernel::Runtime;
+use serde_json::Value as JsonValue;
+
+pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
+    let handle = match &p.arg {
+        Some(Arg::Ident(id)) => id.as_str(),
+        _ => bail!("mod needs @<ident>"),
+    };
+    let body = p.body.as_ref().ok_or_else(|| anyhow::anyhow!("mod needs body"))?;
+    let mut doc = match rt.get_var(handle) {
+        Some(Value::Doc(d)) => d,
+        _ => bail!("handle_unknown"),
+    };
+
+    for node in body {
+        if let Node::Packet(pkt) = node {
+            apply_edit(rt, &mut doc, pkt)?;
+        }
+    }
+
+    rt.set_var(handle, Value::Doc(doc.clone()));
+    Ok(Value::Doc(doc))
+}
+
+fn apply_edit(rt: &Runtime, doc: &mut Document, pkt: &Packet) -> Result<()> {
+    let (op, path) = parse_op(&pkt.op)?;
+    let segments = parse_path(&path)?;
+    match op.as_str() {
+        "comp" => {
+            let val = arg_to_json(rt, pkt.arg.as_ref().ok_or_else(|| anyhow::anyhow!("comp needs value"))?)?;
+            set_value(&mut doc.json, &segments, val, false, true)?;
+        }
+        "comp!" => {
+            let val = arg_to_json(rt, pkt.arg.as_ref().ok_or_else(|| anyhow::anyhow!("comp! needs value"))?)?;
+            set_value(&mut doc.json, &segments, val, true, true)?;
+        }
+        "merge" => {
+            let val = arg_to_json(rt, pkt.arg.as_ref().ok_or_else(|| anyhow::anyhow!("merge needs value"))?)?;
+            if !val.is_object() {
+                bail!("merge requires object value");
+            }
+            let target = navigate(&mut doc.json, &segments, true)?;
+            deep_merge(target, &val);
+        }
+        "del" => {
+            delete(&mut doc.json, &segments)?;
+        }
+        "ins" => {
+            let val = arg_to_json(rt, pkt.arg.as_ref().ok_or_else(|| anyhow::anyhow!("ins needs value"))?)?;
+            set_value(&mut doc.json, &segments, val, false, false)?;
+        }
+        other => bail!("unknown edit op: {other}"),
+    }
+    Ok(())
+}
+
+fn parse_op(op: &str) -> Result<(String, String)> {
+    let start = op.find('(').ok_or_else(|| anyhow::anyhow!("edit missing ("))?;
+    let end = op.rfind(')').ok_or_else(|| anyhow::anyhow!("edit missing )"))?;
+    let name = op[..start].to_string();
+    let path = op[start + 1..end].to_string();
+    Ok((name, path))
+}
+
+#[derive(Clone)]
+enum Segment {
+    Key(String),
+    Index(usize),
+}
+
+fn parse_path(path: &str) -> Result<Vec<Segment>> {
+    let mut segs = Vec::new();
+    let mut buf = String::new();
+    let mut chars = path.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '.' => {
+                if !buf.is_empty() {
+                    segs.push(Segment::Key(buf.clone()));
+                    buf.clear();
+                }
+            }
+            '[' => {
+                if !buf.is_empty() {
+                    segs.push(Segment::Key(buf.clone()));
+                    buf.clear();
+                }
+                let mut num = String::new();
+                while let Some(ch) = chars.next() {
+                    if ch == ']' { break; }
+                    num.push(ch);
+                }
+                segs.push(Segment::Index(num.parse()?));
+            }
+            _ => buf.push(c),
+        }
+    }
+    if !buf.is_empty() {
+        segs.push(Segment::Key(buf));
+    }
+    Ok(segs)
+}
+
+fn navigate<'a>(root: &'a mut JsonValue, segs: &[Segment], create: bool) -> Result<&'a mut JsonValue> {
+    let mut cur = root;
+    for seg in segs {
+        match seg {
+            Segment::Key(k) => {
+                if !cur.is_object() {
+                    if create {
+                        *cur = JsonValue::Object(Default::default());
+                    } else {
+                        bail!("path_missing");
+                    }
+                }
+                cur = cur.as_object_mut().unwrap().entry(k.clone()).or_insert(JsonValue::Null);
+            }
+            Segment::Index(i) => {
+                if !cur.is_array() {
+                    if create {
+                        *cur = JsonValue::Array(Vec::new());
+                    } else {
+                        bail!("path_missing");
+                    }
+                }
+                let arr = cur.as_array_mut().unwrap();
+                if *i >= arr.len() {
+                    if create {
+                        arr.resize(i + 1, JsonValue::Null);
+                    } else {
+                        bail!("path_missing");
+                    }
+                }
+                cur = &mut arr[*i];
+            }
+        }
+    }
+    Ok(cur)
+}
+
+fn set_value(root: &mut JsonValue, segs: &[Segment], val: JsonValue, create: bool, overwrite: bool) -> Result<()> {
+    if segs.is_empty() { bail!("empty path"); }
+    let (head, last) = segs.split_at(segs.len() - 1);
+    let parent = navigate(root, head, create)?;
+    match last[0].clone() {
+        Segment::Key(k) => {
+            if !parent.is_object() {
+                bail!("path_missing");
+            }
+            let obj = parent.as_object_mut().unwrap();
+            if !overwrite && obj.contains_key(&k) {
+                bail!("exists");
+            }
+            obj.insert(k, val);
+        }
+        Segment::Index(i) => {
+            if !parent.is_array() {
+                bail!("path_missing");
+            }
+            let arr = parent.as_array_mut().unwrap();
+            if i >= arr.len() {
+                if create {
+                    arr.resize(i + 1, JsonValue::Null);
+                } else {
+                    bail!("path_missing");
+                }
+            }
+            if !overwrite && arr[i] != JsonValue::Null {
+                bail!("exists");
+            }
+            arr[i] = val;
+        }
+    }
+    Ok(())
+}
+
+fn delete(root: &mut JsonValue, segs: &[Segment]) -> Result<()> {
+    if segs.is_empty() { bail!("empty path"); }
+    let (head, last) = segs.split_at(segs.len() - 1);
+    let parent = navigate(root, head, false)?;
+    match last[0].clone() {
+        Segment::Key(k) => {
+            let obj = parent.as_object_mut().ok_or_else(|| anyhow::anyhow!("path_missing"))?;
+            if obj.remove(&k).is_none() {
+                bail!("path_missing");
+            }
+        }
+        Segment::Index(i) => {
+            let arr = parent.as_array_mut().ok_or_else(|| anyhow::anyhow!("path_missing"))?;
+            if i >= arr.len() {
+                bail!("path_missing");
+            }
+            arr.remove(i);
+        }
+    }
+    Ok(())
+}
+
+fn deep_merge(dest: &mut JsonValue, src: &JsonValue) {
+    match (dest, src) {
+        (JsonValue::Object(a), JsonValue::Object(b)) => {
+            for (k, v) in b {
+                deep_merge(a.entry(k.clone()).or_insert(JsonValue::Null), v);
+            }
+        }
+        (dest, src) => {
+            *dest = src.clone();
+        }
+    }
+}
+
+fn value_to_json(v: Value) -> Result<JsonValue> {
+    Ok(match v {
+        Value::Unit => JsonValue::Null,
+        Value::Bool(b) => JsonValue::Bool(b),
+        Value::Num(n) => JsonValue::Number(serde_json::Number::from_f64(n).ok_or_else(|| anyhow::anyhow!("invalid number"))?),
+        Value::Str(s) => serde_json::from_str(&s).unwrap_or(JsonValue::String(s)),
+        Value::Doc(d) => d.json,
+    })
+}
+
+fn arg_to_json(rt: &Runtime, arg: &Arg) -> Result<JsonValue> {
+    Ok(match arg {
+        Arg::Number(n) => JsonValue::Number(serde_json::Number::from_f64(*n).ok_or_else(|| anyhow::anyhow!("invalid number"))?),
+        Arg::Str(s) => serde_json::from_str(s).unwrap_or(JsonValue::String(s.clone())),
+        Arg::Ident(id) => match id.as_str() {
+            "true" => JsonValue::Bool(true),
+            "false" => JsonValue::Bool(false),
+            "null" => JsonValue::Null,
+            other => {
+                if let Some(v) = rt.get_var(other) {
+                    value_to_json(v)?
+                } else {
+                    JsonValue::String(other.to_string())
+                }
+            }
+        },
+        _ => JsonValue::Null,
+    })
+}

--- a/src/packets/print.rs
+++ b/src/packets/print.rs
@@ -16,5 +16,6 @@ fn pretty(v: &Value) -> String {
         Value::Num(n) => format!("{}", n),
         Value::Bool(b) => format!("{}", b),
         Value::Unit => String::from("()"),
+        Value::Doc(d) => d.json.to_string(),
     }
 }

--- a/src/packets/save.rs
+++ b/src/packets/save.rs
@@ -1,0 +1,103 @@
+use anyhow::{bail, Result};
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+use crate::kernel::ast::Arg;
+use crate::kernel::values::{Document, Value};
+use crate::kernel::{Packet, Runtime};
+
+pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
+    let handle = match &p.arg {
+        Some(Arg::Ident(id)) => id.as_str(),
+        _ => bail!("save needs @<ident>"),
+    };
+
+    if let Some(Value::Doc(doc)) = rt.get_var(handle) {
+        // already registered -> attempt write
+        let mut doc = doc;
+        if doc.json == doc.last_json {
+            return Ok(Value::Doc(doc));
+        }
+
+        let current_mtime = fs::metadata(&doc.path)?.modified()?;
+        if current_mtime != doc.mtime {
+            bail!("changed_on_disk");
+        }
+
+        let bytes = encode(&doc)?;
+
+        let tmp_path = temp_path(&doc.path);
+        {
+            let dir = tmp_path.parent().unwrap_or(Path::new("."));
+            let mut tmp = NamedTempFile::new_in(dir)?;
+            tmp.write_all(&bytes)?;
+            tmp.persist(&tmp_path)?;
+        }
+        fs::rename(&tmp_path, &doc.path)?;
+        let meta = fs::metadata(&doc.path)?;
+        doc.mtime = meta.modified()?;
+        doc.last_json = doc.json.clone();
+        rt.set_var(handle, Value::Doc(doc.clone()));
+        Ok(Value::Doc(doc))
+    } else {
+        // not yet registered -> register from last value
+        match rt.last.clone() {
+            Value::Doc(doc) => {
+                rt.set_var(handle, Value::Doc(doc.clone()));
+                Ok(Value::Doc(doc))
+            }
+            _ => bail!("save needs document in pipeline"),
+        }
+    }
+}
+
+fn encode(doc: &Document) -> Result<Vec<u8>> {
+    let s = match doc.ext.as_str() {
+        "yaml" | "yml" => serde_yaml::to_string(&doc.json)?,
+        "toml" => toml::to_string_pretty(&doc.json)?,
+        "json" | "" => serde_json::to_string_pretty(&doc.json)?,
+        other => bail!("format_unsupported: {other}"),
+    };
+    Ok(s.into_bytes())
+}
+
+fn temp_path(path: &PathBuf) -> PathBuf {
+    let mut tmp = path.clone();
+    if let Some(ext) = tmp.extension() {
+        let mut e = ext.to_os_string();
+        e.push(".tmp");
+        tmp.set_extension(e);
+    } else {
+        tmp.set_extension("tmp");
+    }
+    tmp
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn modifies_and_saves_file() {
+        let base = std::env::temp_dir().join(format!("tgsk_save_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(base.join("sub")).unwrap();
+        fs::write(base.join("red.tgsk"), "").unwrap();
+        fs::write(base.join("config.json"), "{\"a\":{\"b\":1,\"c\":2}}" ).unwrap();
+        let script = base.join("sub").join("main.tgsk");
+        fs::write(&script, "[load@/config.json]>[save@cfg]>[mod@cfg]{[comp(a.b)@2][merge(a)@{\"d\":4}][ins(a.e)@5][del(a.c)]}>[save@cfg]").unwrap();
+
+        let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
+        let mut rt = Runtime::from_entry(&script).unwrap();
+        let _ = rt.eval(&ast).unwrap();
+        let out: serde_json::Value = serde_json::from_str(&fs::read_to_string(base.join("config.json")).unwrap()).unwrap();
+        assert_eq!(out["a"]["b"].as_f64(), Some(2.0));
+        assert_eq!(out["a"]["d"].as_i64(), Some(4));
+        assert_eq!(out["a"]["e"].as_f64(), Some(5.0));
+
+        fs::remove_dir_all(base).unwrap();
+    }
+}

--- a/src/packets/save.rs
+++ b/src/packets/save.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -57,10 +57,34 @@ fn encode(doc: &Document) -> Result<Vec<u8>> {
     let s = match doc.ext.as_str() {
         "yaml" | "yml" => serde_yaml::to_string(&doc.json)?,
         "toml" => toml::to_string_pretty(&doc.json)?,
-        "json" | "" => serde_json::to_string_pretty(&doc.json)?,
+        "json" | "" => {
+            let raw = serde_json::to_string_pretty(&doc.json)?;
+            cleanup_trailing_commas(&raw)
+        }
         other => bail!("format_unsupported: {other}"),
     };
     Ok(s.into_bytes())
+}
+
+fn cleanup_trailing_commas(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let chars: Vec<char> = s.chars().collect();
+    let mut i = 0;
+    while i < chars.len() {
+        if chars[i] == ',' {
+            let mut j = i + 1;
+            while j < chars.len() && chars[j].is_whitespace() {
+                j += 1;
+            }
+            if j < chars.len() && (chars[j] == '}' || chars[j] == ']') {
+                i += 1;
+                continue;
+            }
+        }
+        out.push(chars[i]);
+        i += 1;
+    }
+    out
 }
 
 fn temp_path(path: &PathBuf) -> PathBuf {
@@ -86,17 +110,42 @@ mod tests {
         let _ = fs::remove_dir_all(&base);
         fs::create_dir_all(base.join("sub")).unwrap();
         fs::write(base.join("red.tgsk"), "").unwrap();
-        fs::write(base.join("config.json"), "{\"a\":{\"b\":1,\"c\":2}}" ).unwrap();
+        fs::write(base.join("config.json"), "{\"a\":{\"b\":1,\"c\":2}}").unwrap();
         let script = base.join("sub").join("main.tgsk");
         fs::write(&script, "[load@/config.json]>[save@cfg]>[mod@cfg]{[comp(a.b)@2][merge(a)@{\"d\":4}][ins(a.e)@5][del(a.c)]}>[save@cfg]").unwrap();
 
         let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
         let mut rt = Runtime::from_entry(&script).unwrap();
         let _ = rt.eval(&ast).unwrap();
-        let out: serde_json::Value = serde_json::from_str(&fs::read_to_string(base.join("config.json")).unwrap()).unwrap();
+        let out: serde_json::Value =
+            serde_json::from_str(&fs::read_to_string(base.join("config.json")).unwrap()).unwrap();
         assert_eq!(out["a"]["b"].as_f64(), Some(2.0));
         assert_eq!(out["a"]["d"].as_i64(), Some(4));
         assert_eq!(out["a"]["e"].as_f64(), Some(5.0));
+
+        fs::remove_dir_all(base).unwrap();
+    }
+
+    #[test]
+    fn deleting_last_key_writes_valid_json() {
+        let base = std::env::temp_dir().join(format!("tgsk_trailing_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(base.join("sub")).unwrap();
+        fs::write(base.join("red.tgsk"), "").unwrap();
+        fs::write(base.join("config.json"), "{\"greeting\":\"hi\",\"test\":1}").unwrap();
+        let script = base.join("sub").join("main.tgsk");
+        fs::write(
+            &script,
+            "[load@/config.json]>[save@cfg]>[mod@cfg]{[del(test)]}>[save@cfg]",
+        )
+        .unwrap();
+
+        let ast = crate::router::parse(&fs::read_to_string(&script).unwrap()).unwrap();
+        let mut rt = Runtime::from_entry(&script).unwrap();
+        let _ = rt.eval(&ast).unwrap();
+        let content = fs::read_to_string(base.join("config.json")).unwrap();
+        serde_json::from_str::<serde_json::Value>(&content).expect("valid json");
+        assert!(!content.contains(",\n}"));
 
         fs::remove_dir_all(base).unwrap();
     }


### PR DESCRIPTION
## Summary
- introduce `Document` value type carrying JSON plus file metadata
- add `[save]` packet to register handles and atomically write updated documents
- add `[mod]` packet with `comp`, `merge`, `del`, and `ins` edit operations
- extend `[load]` to decode files into `Document`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68adf29dd890832eb889bb8df358e175