### PR TITLE
docs: document load/merge packets for TagSpeak

### DIFF
--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -77,10 +77,78 @@ Read aloud: “Take this data (5+5), then tell me the result.”
   ```
 
 ### [loop]
-- **Role:** Repeat a block N times.  
+- **Role:** Repeat a block N times.
 - **Forms:**
-  - `[loop@3]{ ... }` (inline loop)  
+  - `[loop@3]{ ... }` (inline loop)
   - `[funct:step]{ ... } … [loop3@step]` (named loop)
+
+### [load]
+- **Role:** Read data from a file.
+- **Input:** File path.
+- **Output:** File contents as a value.
+- **Example:**
+  ```tgsk
+  [load@data.json] > [print]
+  ```
+
+### [save]
+- **Role:** Write the last value to a file.
+- **Input:** File path or `as@file` when saving a variable.
+- **Output:** `Unit`.
+- **Example:**
+  ```tgsk
+  [math@1+1] > [save@result.txt]
+  ```
+
+### [mod]
+- **Role:** Open a stored value for modification.
+- **Usage:** `[mod@Var]{ ... }` where inner packets mutate `Var`.
+- **Inner Packets:** `[comp]`, `[comp!]`, `[merge]`, `[del]`, `[ins]`.
+
+| operation | behavior |
+|-----------|----------|
+| `comp`  | Replace value at the path; the parent must already exist. |
+| `comp!` | Replace value, creating any missing parents along the path (object only). |
+| `merge` | Deep-merge an object into the existing object at the path (object only). |
+| `del`   | Delete the value at the path; error if missing. |
+| `ins`   | Insert a new value; error if the path already exists. |
+
+### [merge]
+- **Role:** Combine two JSON/YAML/TOML structures.
+- **Input:** Source value to merge into the current context.
+- **Behavior:** Keys from the source overwrite or extend the target.
+- **Example:**
+  ```tgsk
+  [load@first.json]  > [save@A]
+  [load@second.json] > [save@B]
+
+  [mod@A]{ [merge(.)@B] }
+    > [save(as@merged.json)@A]
+  ```
+
+### [ins]
+- **Role:** Insert or replace data inside the current value opened by `[mod]`.
+- **Input:** Structure to insert (`{ key: value }`, array, etc.).
+- **Behavior:** Adds new keys or indices; overwrites existing ones.
+- **Example:**
+  ```tgsk
+  [load@profile.json] > [save@P]
+
+  [mod@P]{ [ins(.)@{ city:"Wonderland", hobby:"Adventuring" }] }
+    > [save(as@profile.json)@P]
+  ```
+
+### [del]
+- **Role:** Remove a key or index from the current value opened by `[mod]`.
+- **Input:** Path to delete (`key`, `path.to.key`, `3`, etc.).
+- **Behavior:** Deletes the specified field or element if it exists.
+- **Example:**
+  ```tgsk
+  [load@profile.json] > [save@P]
+
+  [mod@P]{ [del@obsolete] }
+    > [save(as@clean.json)@P]
+  ```
 
 ---
 


### PR DESCRIPTION
## Summary
- document `[load]`, `[save]`, `[mod]`, and `[merge]` packets
- explain `[ins]` and `[del]` edit packets within `[mod]`
- enumerate all `[mod]` edit operations including `[comp]` and `[comp!]`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ae0dc18488832e87b97ca711860821