### PR TITLE
Add call packet and structured logging

### DIFF
--- a/docs/Tagspeak_101.md
+++ b/docs/Tagspeak_101.md
@@ -155,6 +155,17 @@ anyhow = "1"
 serde = "1"
 ```
 
+### Functions
+
+```tgsk
+[funct@greet]{
+  [msg@"hi"]
+}
+[call@greet]
+```
+
+→ defines a reusable `greet` block then runs it, leaving `"hi"` as the current value.
+
 ---
 
 ## Design Principles

--- a/examples/structured_log.tgsk
+++ b/examples/structured_log.tgsk
@@ -1,0 +1,9 @@
+[funct@profile]{
+  [log(json)@profile.json]{
+    [key(name)@"Saryn"]
+    [sect@stats]{
+      [key(level)@5]
+    }
+  }
+}
+[call@profile]

--- a/src/kernel/runtime.rs
+++ b/src/kernel/runtime.rs
@@ -122,7 +122,7 @@ impl Runtime {
     fn eval_packet(&mut self, p: &Packet) -> Result<Value> {
         match (p.ns.as_deref(), p.op.as_str()) {
             // namespaced
-            (Some("funct"), _) => crate::packets::funct::handle(self, p),
+            (Some("funct"), _) | (None, "funct") => crate::packets::funct::handle(self, p),
 
             // core
             (None, "note") => crate::packets::note::handle(self, p),
@@ -136,7 +136,8 @@ impl Runtime {
             (None, "int") => crate::packets::int::handle(self, p),
             (None, "bool") => crate::packets::r#bool::handle(self, p),
             (None, "msg") => crate::packets::msg::handle(self, p),
-            (None, "log") => crate::packets::log::handle(self, p),
+            (None, op) if op.starts_with("log") => crate::packets::log::handle(self, p),
+            (None, "call") => crate::packets::call::handle(self, p),
 
             // loop forms: [loop3@tag] or [loop@N]{...}
             (None, op) if op.starts_with("loop") => crate::packets::r#loop::handle(self, p),

--- a/src/packets/call.rs
+++ b/src/packets/call.rs
@@ -1,0 +1,45 @@
+use anyhow::{bail, Result};
+use crate::kernel::ast::Arg;
+use crate::kernel::{Packet, Runtime, Value};
+
+pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
+    let name = match p.arg.as_ref() {
+        Some(Arg::Ident(s)) | Some(Arg::Str(s)) => s.clone(),
+        _ => bail!("call needs @function_name"),
+    };
+
+    let body = rt
+        .tags
+        .get(&name)
+        .cloned()
+        .ok_or_else(|| anyhow::anyhow!(format!("undefined function: {name}")))?;
+
+    let mut last = Value::Unit;
+    for node in body {
+        last = rt.eval(&node)?;
+    }
+    Ok(last)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::router;
+    use std::fs;
+
+    #[test]
+    fn calls_defined_function() -> Result<()> {
+        let base = std::env::temp_dir().join(format!("tgsk_call_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base)?;
+        fs::write(base.join("red.tgsk"), "")?;
+        let script = base.join("main.tgsk");
+        fs::write(&script, "[funct@hello]{[msg@\"hi\"]}>[call@hello]")?;
+        let node = router::parse(&fs::read_to_string(&script)? )?;
+        let mut rt = Runtime::from_entry(&script)?;
+        let val = rt.eval(&node)?;
+        assert_eq!(val, Value::Str("hi".to_string()));
+        fs::remove_dir_all(base)?;
+        Ok(())
+    }
+}

--- a/src/packets/funct.rs
+++ b/src/packets/funct.rs
@@ -1,12 +1,24 @@
 use anyhow::{Result, bail};
+use crate::kernel::ast::Arg;
 use crate::kernel::{Runtime, Value, Packet};
 
 pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
-    // [funct:tag]{ ... }  => ns = Some("funct"), op = "tag", body = Some(...)
-    let tag = p.op.as_str();
-    let body = p.body.as_ref()
+    let tag = if p.ns.as_deref() == Some("funct") {
+        p.op.clone()
+    } else if p.ns.is_none() && p.op == "funct" {
+        match p.arg.as_ref() {
+            Some(Arg::Ident(s)) | Some(Arg::Str(s)) => s.clone(),
+            _ => bail!("funct needs @name"),
+        }
+    } else {
+        bail!("invalid funct packet");
+    };
+
+    let body = p
+        .body
+        .as_ref()
         .ok_or_else(|| anyhow::anyhow!("funct requires a {{ ... }} body"))?;
-    if tag.is_empty() { bail!("funct needs a tag name: [funct:tag]{{...}}"); }
-    rt.register_tag(tag, body.clone());
+    if tag.is_empty() { bail!("funct needs a tag name"); }
+    rt.register_tag(&tag, body.clone());
     Ok(Value::Unit)
 }

--- a/src/packets/log.rs
+++ b/src/packets/log.rs
@@ -1,54 +1,105 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 
-use crate::kernel::ast::Arg;
-use crate::kernel::fs_guard::resolve;
-use crate::kernel::{Packet, Runtime, Value};
+use serde_json::{Map, Value as JsonValue};
 
-fn to_json(v: &Value) -> serde_json::Value {
+use crate::kernel::ast::{Arg, Node, Packet};
+use crate::kernel::fs_guard::resolve;
+use crate::kernel::{Runtime, Value};
+
+fn to_json(v: &Value) -> JsonValue {
     match v {
-        Value::Unit => serde_json::Value::Null,
-        Value::Bool(b) => serde_json::Value::Bool(*b),
+        Value::Unit => JsonValue::Null,
+        Value::Bool(b) => JsonValue::Bool(*b),
         Value::Num(n) => serde_json::Number::from_f64(*n)
-            .map(serde_json::Value::Number)
-            .unwrap_or(serde_json::Value::Null),
-        Value::Str(s) => serde_json::Value::String(s.clone()),
+            .map(JsonValue::Number)
+            .unwrap_or(JsonValue::Null),
+        Value::Str(s) => JsonValue::String(s.clone()),
         Value::Doc(d) => d.json.clone(),
     }
 }
 
-pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
-    let raw = match &p.arg {
-        Some(Arg::Str(s)) => s,
-        _ => bail!("log needs @<path>"),
-    };
+fn extract_fmt(op: &str) -> Option<&str> {
+    op.strip_prefix("log(").and_then(|s| s.strip_suffix(')'))
+}
 
+fn build_struct(rt: &mut Runtime, body: &[Node]) -> Result<JsonValue> {
+    let mut map = Map::new();
+    for node in body {
+        if let Node::Packet(pkt) = node {
+            if let Some(name) = pkt.op.strip_prefix("key(").and_then(|s| s.strip_suffix(')')) {
+                let arg = pkt.arg.as_ref().ok_or_else(|| anyhow::anyhow!("key needs @value"))?;
+                let val = rt.resolve_arg(arg)?;
+                map.insert(name.to_string(), to_json(&val));
+            } else if pkt.op == "sect" {
+                let section = match pkt.arg.as_ref() {
+                    Some(Arg::Ident(s)) | Some(Arg::Str(s)) => s.clone(),
+                    _ => bail!("sect needs @name"),
+                };
+                let inner = pkt.body.as_ref().ok_or_else(|| anyhow::anyhow!("sect requires body"))?;
+                map.insert(section, build_struct(rt, inner)?);
+            }
+        }
+    }
+    Ok(JsonValue::Object(map))
+}
+
+fn resolve_path(rt: &Runtime, raw: &str) -> Result<std::path::PathBuf> {
     let root = rt
         .effective_root
         .as_ref()
         .ok_or_else(|| anyhow::anyhow!("no red.tgsk root"))?;
-
-    let rel = if raw.starts_with('/') { &raw[1..] } else { raw.as_str() };
+    let rel = if raw.starts_with('/') { &raw[1..] } else { raw };
     let candidate = if raw.starts_with('/') {
         Path::new(rel).to_path_buf()
     } else {
         rt.cwd.join(rel)
     };
-    let path = resolve(root, &candidate)?;
+    resolve(root, &candidate)
+}
 
+fn quick_dump(rt: &mut Runtime, raw: &str) -> Result<Value> {
+    let path = resolve_path(rt, raw)?;
     let json = serde_json::to_string_pretty(&to_json(&rt.last))?;
     let mut file = OpenOptions::new().create(true).append(true).open(path)?;
     writeln!(file, "{}", json)?;
     Ok(rt.last.clone())
 }
 
+fn structured_dump(rt: &mut Runtime, p: &Packet, fmt: &str, raw: &str) -> Result<Value> {
+    let path = resolve_path(rt, raw)?;
+    let body = p.body.as_ref().ok_or_else(|| anyhow::anyhow!("log({fmt}) needs {{..}}"))?;
+    let data = build_struct(rt, body)?;
+    let content = match fmt {
+        "json" => serde_json::to_string_pretty(&data)?,
+        "yaml" => serde_yaml::to_string(&data)?,
+        "toml" => toml::to_string_pretty(&data)?,
+        other => bail!("unsupported format: {other}"),
+    };
+    let mut file = OpenOptions::new().create(true).write(true).truncate(true).open(path)?;
+    write!(file, "{}", content)?;
+    Ok(rt.last.clone())
+}
+
+pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
+    let raw = match &p.arg {
+        Some(Arg::Str(s)) | Some(Arg::Ident(s)) => s,
+        _ => bail!("log needs @<path>"),
+    };
+    if let Some(fmt) = extract_fmt(&p.op) {
+        structured_dump(rt, p, fmt, raw)
+    } else {
+        quick_dump(rt, raw)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fs;
     use crate::router;
+    use std::fs;
 
     #[test]
     fn writes_json() -> Result<()> {
@@ -63,6 +114,24 @@ mod tests {
         rt.eval(&node)?;
         let content = fs::read_to_string(base.join("out.json"))?;
         assert!(content.contains("\"hi\""));
+        fs::remove_dir_all(base)?;
+        Ok(())
+    }
+
+    #[test]
+    fn writes_structured_yaml() -> Result<()> {
+        let base = std::env::temp_dir().join(format!("tgsk_log_struct_test_{}", std::process::id()));
+        let _ = fs::remove_dir_all(&base);
+        fs::create_dir_all(&base)?;
+        fs::write(base.join("red.tgsk"), "")?;
+        let script = base.join("main.tgsk");
+        let src = "[log(yaml)@out.yaml]{[key(name)@\"Saryn\"]}";
+        fs::write(&script, src)?;
+        let node = router::parse(&fs::read_to_string(&script)? )?;
+        let mut rt = Runtime::from_entry(&script)?;
+        rt.eval(&node)?;
+        let content = fs::read_to_string(base.join("out.yaml"))?;
+        assert!(content.contains("name: Saryn"));
         fs::remove_dir_all(base)?;
         Ok(())
     }

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1,5 +1,6 @@
 pub mod conditionals;
 pub mod funct;
+pub mod call;
 pub mod load;
 pub mod r#loop;
 pub mod math;


### PR DESCRIPTION
## Summary
- add `[call@name]` packet to run functions
- expand `[log]` packet with structured JSON/YAML/TOML logging via `[key]` and `[sect]`
- document new packets and show function usage

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68af6879b294832eaff1e0aea5ba3679