### PR TITLE
Fix build errors and restore packet modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -430,6 +430,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -548,6 +554,12 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+
+[[package]]
+name = "itoa"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -891,7 +903,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d6ea3c4595b96363c13943497db34af4460fb474a95c43f4446ad341b8c9785"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]
@@ -901,7 +913,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
 dependencies = [
  "once_cell",
- "toml_edit",
+ "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -1005,6 +1017,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
+name = "ryu"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1050,6 +1068,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
+dependencies = [
+ "itoa",
+ "memchr",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -1158,11 +1210,28 @@ dependencies = [
  "meval",
  "native-windows-derive",
  "native-windows-gui",
+ "serde_json",
+ "serde_yaml",
+ "tempfile",
+ "toml 0.8.23",
  "which",
  "windows-sys 0.52.0",
  "winit",
  "winreg",
  "winres",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1220,10 +1289,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
 name = "toml_datetime"
 version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "toml_edit"
@@ -1233,8 +1317,28 @@ checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
  "indexmap",
  "toml_datetime",
- "winnow",
+ "winnow 0.5.40",
 ]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow 0.7.13",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "ttf-parser"
@@ -1253,6 +1357,12 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "utf8parse"
@@ -1892,6 +2002,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "winreg"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1907,7 +2026,7 @@ version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b68db261ef59e9e52806f688020631e987592bd83619edccda9c47d42cde4f6c"
 dependencies = [
- "toml",
+ "toml 0.5.11",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ dirs = "5"
 clap = { version = "4.5.2", features = ["derive"] }
 meval = "0.2"
 anyhow = "1"
+serde_json = "1"
+serde_yaml = "0.9"
+toml = "0.8"
+tempfile = "3"
 
 # Windows-only deps
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "windows")]
+#[cfg(target_os = "windows")]
 fn main() {
     let mut res = winres::WindowsResource::new();
     res.set_icon("misc/Tagspeak.ico");
@@ -6,5 +6,5 @@ fn main() {
     res.compile().expect("Failed to embed resources");
 }
 
-#[cfg(not(feature = "windows"))]
+#[cfg(not(target_os = "windows"))]
 fn main() {}

--- a/src/bin/tagspeak_setup.rs
+++ b/src/bin/tagspeak_setup.rs
@@ -1,16 +1,26 @@
-#![cfg(feature = "windows")]
-#![windows_subsystem = "windows"]
+#![cfg_attr(target_os = "windows", windows_subsystem = "windows")]
+
+#[cfg(target_os = "windows")]
 use anyhow::Result;
+#[cfg(target_os = "windows")]
 use native_windows_derive as nwd;
+#[cfg(target_os = "windows")]
 use native_windows_gui as nwg;
+#[cfg(target_os = "windows")]
 use nwg::NativeUi;
+#[cfg(target_os = "windows")]
 use std::path::PathBuf;
+#[cfg(target_os = "windows")]
 use windows_sys::Win32::UI::Shell::{SHCNE_ASSOCCHANGED, SHCNF_IDLIST, SHChangeNotify};
+#[cfg(target_os = "windows")]
 use winreg::{RegKey, enums::*};
 
+#[cfg(target_os = "windows")]
 const PROGID: &str = "TagSpeakFile";
+#[cfg(target_os = "windows")]
 const DISPLAY: &str = "TagSpeak Script";
 
+#[cfg(target_os = "windows")]
 #[derive(Default, nwd::NwgUi)]
 pub struct App {
     #[nwg_control(size: (560, 260), title: "TagSpeak Setup", flags: "WINDOW|VISIBLE")]
@@ -68,6 +78,7 @@ pub struct App {
     btn_build: nwg::Button,
 }
 
+#[cfg(target_os = "windows")]
 impl App {
     fn init_defaults(&self) {
         // try to auto-fill engine path (…\tagspeak_rs\target\release\tagspeak_rs.exe)
@@ -221,6 +232,7 @@ impl App {
     }
 }
 
+#[cfg(target_os = "windows")]
 fn find_cargo() -> std::path::PathBuf {
     use std::path::PathBuf;
     // Try PATH first
@@ -233,6 +245,7 @@ fn find_cargo() -> std::path::PathBuf {
     p
 }
 
+#[cfg(target_os = "windows")]
 fn main() {
     nwg::init().expect("NWG init failed");
     nwg::Font::set_global_family("Segoe UI").ok();
@@ -248,7 +261,11 @@ fn main() {
     nwg::dispatch_thread_events();
 }
 
+#[cfg(not(target_os = "windows"))]
+fn main() {}
+
 /* ---------- registry helpers ---------- */
+#[cfg(target_os = "windows")]
 fn do_install(engine_exe: PathBuf) -> Result<()> {
     if !engine_exe.exists() {
         anyhow::bail!("Engine exe not found: {}", engine_exe.display());
@@ -274,6 +291,7 @@ fn do_install(engine_exe: PathBuf) -> Result<()> {
     Ok(())
 }
 
+#[cfg(target_os = "windows")]
 fn do_uninstall() -> Result<()> {
     let hkcu = RegKey::predef(HKEY_CURRENT_USER);
     let classes = hkcu.open_subkey_with_flags("Software\\Classes", KEY_ALL_ACCESS)?;
@@ -287,6 +305,7 @@ fn do_uninstall() -> Result<()> {
 ///
 /// # Errors
 /// Currently returns `Ok(())` because [`SHChangeNotify`] has no error reporting.
+#[cfg(target_os = "windows")]
 fn refresh_icons() -> Result<()> {
     // [myth] goal: refresh icons without tanking Explorer
     // [myth] tradeoff: if the call fails, we don't get feedback

--- a/src/bin/tagspeak_setup_linux.rs
+++ b/src/bin/tagspeak_setup_linux.rs
@@ -1,26 +1,32 @@
-#![cfg(feature = "linux")]
-
+#[cfg(target_os = "linux")]
 use winit::event::{Event, WindowEvent};
-use winit::event_loop::{ControlFlow, EventLoop};
+#[cfg(target_os = "linux")]
+use winit::event_loop::EventLoop;
+#[cfg(target_os = "linux")]
 use winit::window::WindowBuilder;
 
+#[cfg(target_os = "linux")]
 fn main() {
-    let event_loop = EventLoop::new();
+    let event_loop = EventLoop::new().expect("event loop");
     let _window = WindowBuilder::new()
         .with_title("TagSpeak Setup")
         .build(&event_loop)
         .expect("window");
 
-    event_loop.run(|event, _, control_flow| {
-        *control_flow = ControlFlow::Wait;
-        if matches!(
-            event,
-            Event::WindowEvent {
-                event: WindowEvent::CloseRequested,
-                ..
+    event_loop
+        .run(|event, elwt| {
+            if matches!(
+                event,
+                Event::WindowEvent {
+                    event: WindowEvent::CloseRequested,
+                    ..
+                }
+            ) {
+                elwt.exit();
             }
-        ) {
-            *control_flow = ControlFlow::Exit;
-        }
-    });
+        })
+        .expect("event loop run");
 }
+
+#[cfg(not(target_os = "linux"))]
+fn main() {}

--- a/src/kernel/runtime.rs
+++ b/src/kernel/runtime.rs
@@ -1,4 +1,5 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
 use anyhow::{Result, bail};
 
 use crate::kernel::ast::{Arg, BExpr, Node, Packet};
@@ -44,7 +45,10 @@ impl Runtime {
     }
 
     // ---- variables ----
-    pub fn set_var(&mut self, name: &str, val: Value) { self.vars.insert(name.to_string(), val); }
+    pub fn set_var(&mut self, name: &str, val: Value) -> Result<()> {
+        self.vars.insert(name.to_string(), val);
+        Ok(())
+    }
     pub fn get_var(&self, name: &str) -> Option<Value> { self.vars.get(name).cloned() }
 
     // ---- tags ----
@@ -117,7 +121,8 @@ impl Runtime {
         self.get_var(name).and_then(|v| v.try_num())
     }
     pub fn set_num(&mut self, name: &str, n: f64) -> Result<()> {
-        self.set_var(name, Value::Num(n))
+        self.set_var(name, Value::Num(n))?;
+        Ok(())
     }
 
     fn eval_if(&mut self, cond: &BExpr) -> Result<bool> {

--- a/src/packets/load.rs
+++ b/src/packets/load.rs
@@ -1,8 +1,3 @@
-@ -129,3 +129,125 @@ mod tests {
-    }
-}
-
-
 use anyhow::Result;
 use std::fs;
 use std::path::Path;

--- a/src/packets/mod.rs
+++ b/src/packets/mod.rs
@@ -1,2 +1,14 @@
 pub mod conditionals;
 pub mod funct;
+pub mod bool;
+pub mod int;
+pub mod load;
+pub mod log;
+pub mod r#loop;
+pub mod math;
+pub mod modify;
+pub mod msg;
+pub mod note;
+pub mod print;
+pub mod save;
+pub mod store;

--- a/src/packets/print.rs
+++ b/src/packets/print.rs
@@ -1,7 +1,5 @@
-use crate::kernel::{Packet, Runtime, Value};
 use anyhow::Result;
-use crate::kernel::{Runtime, Value, Packet};
-use crate::kernel::ast::Arg;
+use crate::kernel::{Packet, Runtime, Value};
 
 pub fn handle(rt: &mut Runtime, p: &Packet) -> Result<Value> {
     let v = match p.arg.as_ref() {
@@ -17,6 +15,7 @@ fn pretty(v: &Value) -> String {
         Value::Str(s) => s.clone(),
         Value::Num(n) => format!("{}", n),
         Value::Bool(b) => format!("{}", b),
+        Value::Doc(_) => String::from("<doc>"),
         Value::Unit    => String::from("()"),
     }
 }


### PR DESCRIPTION
## Summary
- gate setup binaries and build script on target OS
- export packet modules and add missing dependencies
- clean up runtime helpers and packet handlers

## Testing
- `cargo build`
- `cargo test` *(fails: unknown operation: (None, "bool"), unknown operation: (None, "msg"), unknown operation: (None, "load"), assertion failed in store context test)*

------
https://chatgpt.com/codex/tasks/task_e_68af73b8a8c4832ea4e11960b4db0541