### PR TITLE
chore: add vscode setup

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+    "recommendations": [
+        "rust-lang.rust-analyzer",
+        "vadimcn.vscode-lldb",
+        "tamasfe.even-better-toml"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+    "rust-analyzer.checkOnSave.command": "clippy",
+    "rust-analyzer.cargo.features": "all",
+    "files.associations": {
+        "*.tgsk": "plaintext"
+    },
+    "[rust]": {
+        "editor.defaultFormatter": "rust-lang.rust-analyzer",
+        "editor.formatOnSave": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,23 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "cargo build",
+            "type": "shell",
+            "command": "cargo build",
+            "problemMatcher": ["$rustc"]
+        },
+        {
+            "label": "cargo test",
+            "type": "shell",
+            "command": "cargo test",
+            "problemMatcher": ["$rustc"]
+        },
+        {
+            "label": "cargo clippy",
+            "type": "shell",
+            "command": "cargo clippy",
+            "problemMatcher": ["$rustc"]
+        }
+    ]
+}

--- a/setup_vscode.tgsk
+++ b/setup_vscode.tgsk
@@ -1,0 +1,19 @@
+[log(json)@.vscode/settings.json]{
+  [key(rust-analyzer.checkOnSave.command)@"clippy"]
+  [key(rust-analyzer.cargo.features)@"all"]
+  [sect@files.associations]{
+    [key("*.tgsk")@"plaintext"]
+  }
+  [sect@[rust]]{
+    [key(editor.defaultFormatter)@"rust-lang.rust-analyzer"]
+    [key(editor.formatOnSave)@true]
+  }
+}
+
+[log(json)@.vscode/extensions.json]{
+  [key(recommendations)@[
+    "rust-lang.rust-analyzer",
+    "vadimcn.vscode-lldb",
+    "tamasfe.even-better-toml"
+  ]]
+}


### PR DESCRIPTION
## Summary
- add VS Code settings for Rust and TagSpeak files
- provide VS Code tasks for building, testing, and linting
- include TagSpeak script to generate editor config

## Testing
- `cargo test` *(fails: unknown operation: (None, "load"))*

------
https://chatgpt.com/codex/tasks/task_e_68af89450248832e99e9593a9bf417ce