### PR TITLE
docs: clarify TagSpeak reference and README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # TagSpeak RS
 
-TagSpeak is a symbolic, packet-based language designed to be **human-readable** and **machine-parsable**.  
-This Rust implementation (`tagspeak_rs`) provides an interpreter that can parse and execute `.tgsk` scripts.
+TagSpeak is a symbolic, packet-based language designed to be **human-readable** and **machine-parsable**.
+This Rust implementation (`tagspeak_rs`) provides an interpreter for `.tgsk` scripts. See [TagSpeak 101](Tagspeak_101.md) for a quick reference.
 
 ---
 
@@ -15,19 +15,19 @@ This Rust implementation (`tagspeak_rs`) provides an interpreter that can parse 
 ---
 
 ## 🔧 Features Implemented
-- **math** → evaluate expressions with `meval`
+- **math** → evaluate expressions
 - **store** → assign variables
 - **print** → output values or strings
-- **note** → dev/debug annotation
-- **funct** → define named blocks
-- **loop** → two styles:
-  - `[loop@3]{ ... }` → inline loop
-  - `[funct:step]{ ... } … [loop3@step]` → tag loop (modular, reusable)
-- **load** → load JSON/YAML/TOML files **relative to the nearest `red.tgsk`**  
-  (`[load@./file/path/relative/to/red.tgsk]`)
-- **red.tgsk** → Root file marker/sentinel file. Must exist in your project root; all file access is sandboxed to this boundary.
-
-...
+- **note** → inline documentation
+- **funct** → define reusable blocks
+- **call** → invoke functions (`[call@name]`)
+- **loop** → `[loop3]{ ... }` or `[loop3@funct]`
+- **if/or/else** → conditional branching
+- **load** → read JSON/YAML/TOML based on file extension
+- **save** → persist runtime state
+- **log** → structured file logging (`[log(json|yaml|toml)@file]{...}`)
+- **mod** → edit in-memory documents
+- **red.tgsk** → sentinel file marking the project root for file access
 
 ### Notes
 
@@ -57,6 +57,6 @@ cargo test
 ## 🛣 Roadmap
 - [x] math/store/print/note
 - [x] funct + loop (inline + tag)
-- [ ] call tags directly (`[call@step]`)
-- [ ] conditionals (`[if@(x>2)]{...}[else]{...}`)
+- [x] call tags directly (`[call@step]`)
+- [x] conditionals (`[if@(x>2)]{...}[else]{...}`)
 - [ ] modular imports / red.tgsk boundaries

--- a/docs/Tagspeak_101.md
+++ b/docs/Tagspeak_101.md
@@ -1,37 +1,34 @@
 # TagSpeak 101
 
+### Audience
+
+This file is a quick reference for **Codex-style agents** and humans who need to read or write TagSpeak (`.tgsk`) programs.
+
+---
+
 ## What is TagSpeak?
 
-TagSpeak is a **dataflow-oriented DSL** designed for clarity and accessibility between humans and AI models. Unlike imperative languages, TagSpeak flows data through chained packets, each represented as `[packet@arg]` blocks. The goal is to be both **human-readable** and **machine-parsable**.
+TagSpeak is a **dataflow-oriented DSL**. Instead of mutating state with imperative statements, values move left → right through chained **packets**. Each packet has the shape `[packet@arg]` and transforms the value it receives.
+
+Data is always carried forward by the `>` connector:
+
+```tgsk
+[msg@"hi"]>[store@greeting]>[print]
+```
+
+1. `[msg]` produces "hi".
+2. `[store]` saves it under `greeting`.
+3. `[print]` outputs it.
+
+Keep TagSpeak syntax intact—**do not translate** packets to Rust, Python, or other languages.
 
 ---
 
 ## Core Concepts
 
-1. **Packets**
-   Everything in TagSpeak is a `[packet]`. Packets transform, store, or route data.
-
-   Example:
-
-   ```tgsk
-   [math@5+5]>[print]
-   ```
-
-   → outputs `10`
-
-2. **Dataflow, not imperative**
-   Execution flows left to right, through pipes (`>`), carrying values forward.
-
-   Example:
-
-   ```tgsk
-   [msg@"hi"]>[store@greeting]
-   ```
-
-   → stores `hi` as `greeting`.
-
-3. **Inline sugar + canonical packets**
-   Human-friendly syntax (`==`, `>`, etc.) coexists with explicit packets like `[eq]`, `[gt]`, `[and]`.
+1. **Everything is a packet** – packets transform, store, or route data.
+2. **Inline sugar vs. canonical packets** – friendly forms (`>` or `==`) have explicit equivalents (`[pipe]`, `[eq]`). Prefer canonical packets when clarity matters.
+3. **Structured file operations** – when emitting files, prefer `[log(json|yaml|toml)@path]{...}` over ad‑hoc writes.
 
 ---
 
@@ -41,7 +38,7 @@ TagSpeak is a **dataflow-oriented DSL** designed for clarity and accessibility b
 
 * `[msg@"string"]` → create a string literal.
 * `[int@int]` → create an integer.
-* `[bool@true|false]` → create a bool true|false statement.
+* `[bool@true|false]` → create a boolean literal (`true` or `false`).
 * `[note@"message"]` → inline documentation/annotation.
 
 ### Function Packets
@@ -53,7 +50,7 @@ TagSpeak is a **dataflow-oriented DSL** designed for clarity and accessibility b
 ### File Packets
 
 * `[save@file]` → save current runtime state to file.
-* `[load(json|yaml|toml)@file]` → load values/config from a file.
+* `[load@file.ext]` → load values/config from a file; format is inferred from the extension.
 * `[log@file.json]` → dump last value to a JSON file (quick + dirty mode).
 * `[log(json|yaml|toml)@file]{...}` → structured logging mode: build and write formatted docs.
 * `[mod@var]{...}` → edit an in-memory document previously loaded and saved into a variable. Supports operators:
@@ -67,7 +64,9 @@ TagSpeak is a **dataflow-oriented DSL** designed for clarity and accessibility b
 ### Control Flow Packets
 
 * `[loopN]{...}` → repeat enclosed block `N` times.
-* `[cond(condition)]{...}[else]{...}` → conditional branching, run one block if true, else the other.
+* `[if(condition)]{...}` → run block if condition true.
+* `[or(condition)]{...}` → else-if style branch.
+* `[else]{...}` → fallback branch for preceding conditionals.
 * `[funct@name]{...}` → define a reusable function.
 * `[call@name]` → call a function defined with `[funct]`.
 


### PR DESCRIPTION
## Summary
- clarify control flow and loading semantics in TagSpeak 101
- update documentation README with implemented features and quick reference link

## Testing
- `cargo test` *(fails: 4 passed, 9 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68af8ec157b0832e8328329e96d4e431